### PR TITLE
fixing Singularity file

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -1,3 +1,2 @@
 Bootstrap:docker
-From:nextflow:rnatoy:peerj5515
-
+From:nextflow/rnatoy:peerj5515


### PR DESCRIPTION
I noticed the build failing on Singularity hub, and it's just a tiny detail with regard to specifying the docker uri! The old version is:

      Bootstrap:docker
      From:nextflow:rnatoy:peerj5515

and it just needs one tiny tweak to fix!

      Bootstrap:docker
      From:nextflow/rnatoy:peerj5515
      
here is how I tested locally:

      sudo singularity create --size 4000 test.img
      sudo singularity boostrap test.img Singularity

Let me know if this works for you, and if after I can be of help to test things out / debug anything else additionally. Minimally, this should be enough to build the image!